### PR TITLE
fix: correct textcanvas typo issues from #1

### DIFF
--- a/src/charts.rs
+++ b/src/charts.rs
@@ -1277,7 +1277,7 @@ impl Resampling {
     ///
     /// Mean downsampling reduces the number of values by averaging them
     /// out. The data points are split into `n` buckets (where `n` is
-    /// the target resolution), and for each bucket we keep the meanof
+    /// the target resolution), and for each bucket we keep the mean of
     /// the values.
     ///
     /// Compared to min/max downsampling for instance, mean will

--- a/src/textcanvas.rs
+++ b/src/textcanvas.rs
@@ -1469,8 +1469,8 @@ impl TextCanvas {
 
 impl Default for TextCanvas {
     fn default() -> Self {
-        let (width, heigt) = Self::get_default_size();
-        Self::new(width, heigt)
+        let (width, height) = Self::get_default_size();
+        Self::new(width, height)
     }
 }
 


### PR DESCRIPTION
## What changed
- Fixed local binding typo in `TextCanvas::default()` (`heigt` -> `height`)
- Fixed docs typo in `Resampling` comment (`meanof` -> `mean of`)

## Why
This addresses issue #1 with the two small typos called out in the report.

Closes #1