### PR TITLE
fix: correct typos in textcanvas docs and default size

### DIFF
--- a/src/charts.rs
+++ b/src/charts.rs
@@ -1277,7 +1277,7 @@ impl Resampling {
     ///
     /// Mean downsampling reduces the number of values by averaging them
     /// out. The data points are split into `n` buckets (where `n` is
-    /// the target resolution), and for each bucket we keep the meanof
+    /// the target resolution), and for each bucket we keep the mean of
     /// the values.
     ///
     /// Compared to min/max downsampling for instance, mean will

--- a/src/textcanvas.rs
+++ b/src/textcanvas.rs
@@ -1469,8 +1469,8 @@ impl TextCanvas {
 
 impl Default for TextCanvas {
     fn default() -> Self {
-        let (width, heigt) = Self::get_default_size();
-        Self::new(width, heigt)
+        let (width, height) = Self::get_default_size();
+        Self::new(width, height)
     }
 }
 


### PR DESCRIPTION
Fixes #1

Changes:
- Corrects `meanof` to `mean of` in the chart doc comment.
- Corrects the local variable typo `heigt` to `height` in the `Default` implementation.

Verification:
- Confirmed both exact typos existed in the current upstream branch.
- Ran `git diff --check`.
- Confirmed `meanof` and `heigt` no longer appear in the touched files.